### PR TITLE
Add new keyword `Set SSL Verify`, add `data` to requests and fix tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
 #    args: [--without-tool, pep8, --without-tool, pep257]
 
 - repo: https://github.com/guykisel/pre-commit-robotframework-tidy
-  rev: "f5942827aadc04b1637527b8b5c4b2bc1850ca6b"
+  rev: "178d2190fa733d8f4d3f72fed9db6e75a9f65d35"
   hooks:
   - id: robotframework-tidy-wrapper
 

--- a/atest/methods.robot
+++ b/atest/methods.robot
@@ -1,59 +1,57 @@
 *** Settings ***
-Library         REST                        localhost:8273/
-Test setup      DELETE                      http://localhost:8273/state
-
+Library           REST    localhost:8273/
+Test Setup        DELETE    http://localhost:8273/state
 
 *** Variables ***
-&{invalid}=     name=John Galt
-${valid}=       { "name": "Julie Langford" }
-
+&{invalid}=       name=John Galt
+${valid}=         { "name": "Julie Langford" }
 
 *** Test Cases ***
 GET existing user
-    GET         users/1
-    Integer     response status             200
-    Integer     response body id            1
-    String      response body name          Leanne Graham
+    GET    users/1
+    Integer    response status    200
+    Integer    response body id    1
+    String    response body name    Leanne Graham
 
 GET non-existing user
-    GET         /users/1969
-    Integer     response status             404
-    String      response body error         Not found
+    GET    /users/1969
+    Integer    response status    404
+    String    response body error    Not found
 
 GET many users
-    GET         https://jsonplaceholder.typicode.com/users?_limit=3  timeout=1.5
-    Integer     response body 2 id          3
-    GET         http://jsonplaceholder.typicode.com/users      { "_limit": 3 }
-    Array       response body               ${CURDIR}/responses/limit_3.json
+    GET    https://jsonplaceholder.typicode.com/users?_limit=3    timeout=1.5
+    Integer    response body 2 id    3
+    GET    http://jsonplaceholder.typicode.com/users    { "_limit": 3 }
+    Array    response body    ${CURDIR}/responses/limit_3.json
 
 POST with invalid params
-    POST        /users                      ${invalid}
-    Integer     response status             400
-    String      response body error         No property 'id' given
+    POST    /users    ${invalid}
+    Integer    response status    400
+    String    response body error    No property 'id' given
 
 POST with valid params
-    POST        /users                      { "id": 11, "name": "Gil Alexander" }
-    Integer     response status             201
+    POST    /users    { "id": 11, "name": "Gil Alexander" }
+    Integer    response status    201
 
 PUT with valid params
-    PUT         /users/2                    { "isCoding": true }
-    Boolean     response body isCoding      true
-    PUT         /users/2                    { "sleep": null }
-    Null        response body sleep
-    PUT         /users/2                    { "pockets": "", "money": 0.02 }
-    String      response body pockets       ${EMPTY}
-    String      response body pockets       ""
-    Number      response body money         0.02
-    Missing     response body moving
+    PUT    /users/2    { "isCoding": true }
+    Boolean    response body isCoding    true
+    PUT    /users/2    { "sleep": null }
+    Null    response body sleep
+    PUT    /users/2    { "pockets": "", "money": 0.02 }
+    String    response body pockets    ${EMPTY}
+    String    response body pockets    ""
+    Number    response body money    0.02
+    Missing    response body moving
 
 PATCH with valid params
-    GET         "/users/3"                  # quotes are optional
-    String      response body name          Clementine Bauch
-    PATCH       /users/3                    ${valid}
-    String      response body name          Julie Langford
+    GET    "/users/3"    # quotes are optional
+    String    response body name    Clementine Bauch
+    PATCH    /users/3    ${valid}
+    String    response body name    Julie Langford
 
 DELETE existing
-    DELETE      /users/9
-    Integer     response status             200     204
-    GET         /users/9
-    Number      response status             404
+    DELETE    /users/9
+    Integer    response status    200    204
+    GET    /users/9
+    Number    response status    404

--- a/atest/schema.robot
+++ b/atest/schema.robot
@@ -1,84 +1,82 @@
 *** Settings ***
-Library         REST                localhost:8273/
-Suite setup     DELETE              http://localhost:8273/state
-Suite teardown  Rest instances
-Test setup      Set expectations
-Test teardown   Clear expectations
-
+Library           REST    localhost:8273/
+Suite Setup       DELETE    http://localhost:8273/state
+Suite Teardown    Rest instances
+Test Setup        Set expectations
+Test Teardown     Clear expectations
 
 *** Keywords ***
 Set expectations
-    Expect request                  ${CURDIR}/schemas/valid/request.yaml
-    Expect response                 ${CURDIR}/schemas/valid/response.json
-
+    Expect request    ${CURDIR}/schemas/valid/request.yaml
+    Expect response    ${CURDIR}/schemas/valid/response.json
 
 *** Test Cases ***
 GET to existing
-    GET         /users/1
+    GET    /users/1
 
 GET to non-existing
-    [Setup]     Expect response     ${CURDIR}/schemas/invalid/response.json
-    GET         /users/404
+    [Setup]    Expect response    ${CURDIR}/schemas/invalid/response.json
+    GET    /users/404
 
 GET many
-    GET         /users
+    GET    /users
 
 GET many with query "_limit"
-    GET         /users?_limit=10
+    GET    /users?_limit=10
 
 GET many with invalid query
-    GET         /users?_invalid=query
+    GET    /users?_invalid=query
 
 POST with invalid params
-    [Setup]     Expect response     ${CURDIR}/schemas/invalid/response.json
-    POST        /users              { "name": "Alexander James Murphy" }
+    [Setup]    Expect response    ${CURDIR}/schemas/invalid/response.json
+    POST    /users    { "name": "Alexander James Murphy" }
 
 POST with valid params
-    &{response}=    GET             /users/1
-    &{body}         Input           ${response.body}
-    ${body.id}=     Input           50
-    POST        /users              ${body}
+    &{response}=    GET    /users/1
+    &{body}    Input    ${response.body}
+    ${body.id}=    Input    50
+    POST    /users    ${body}
 
 POST with missing params
-    [Setup]     Expect response     ${CURDIR}/schemas/invalid/response.json
-    POST        /users
+    [Setup]    Expect response    ${CURDIR}/schemas/invalid/response.json
+    POST    /users
 
 PUT to non-existing
-    [Setup]     Expect response     ${CURDIR}/schemas/invalid/response.json
-    PUT         /users/2043
+    [Setup]    Expect response    ${CURDIR}/schemas/invalid/response.json
+    PUT    /users/2043
 
 PUT with invalid params
-    [Setup]     Expect response     ${CURDIR}/schemas/invalid/response.json
-    PUT         /users/50            { "id": 1801 }
+    [Setup]    Expect response    ${CURDIR}/schemas/invalid/response.json
+    PUT    /users/50    { "id": 1801 }
 
 PUT with valid params
-    PUT         /users/2            { "address": { "city": "Delta City" } }
+    PUT    /users/2    { "address": { "city": "Delta City" } }
 
 PUT with missing params
-    [Setup]     Expect response     ${CURDIR}/schemas/invalid/response.json
-    PUT         /users/2
+    [Setup]    Expect response    ${CURDIR}/schemas/invalid/response.json
+    PUT    /users/2
 
 PATCH to non-existing
-    [Setup]     Expect response     ${CURDIR}/schemas/invalid/response.json
-    PATCH       /users/2043
+    [Setup]    Expect response    ${CURDIR}/schemas/invalid/response.json
+    PATCH    /users/2043
 
 PATCH with invalid params
-    [Setup]     Expect response     ${CURDIR}/schemas/invalid/response.json
-    PATCH       /users/2            { "nickname": "murph" }
+    [Setup]    Expect response    ${CURDIR}/schemas/invalid/response.json
+    PATCH    /users/2    { "nickname": "murph" }
 
 PATCH with valid params
-    PATCH       /users/2            { "username": "murph" }
+    PATCH    /users/2    { "username": "murph" }
 
 PATCH with missing params
-    [Setup]     Expect response     ${CURDIR}/schemas/invalid/response.json
-    PATCH       /users/2
+    [Setup]    Expect response    ${CURDIR}/schemas/invalid/response.json
+    PATCH    /users/2
 
 DELETE to non-existing
-    [Setup]     Expect response     ${CURDIR}/schemas/invalid/response.json
-    DELETE      /users/2043
+    [Setup]    Expect response    ${CURDIR}/schemas/invalid/response.json
+    DELETE    /users/2043
 
 DELETE to existing
-    DELETE      /users/10
+    DELETE    /users/10
 
 DELETE to invalid, but with no validations
-    DELETE      /invalid            validate=${False}
+    DELETE    /invalid    validate=${False}

--- a/atest/spec_json.robot
+++ b/atest/spec_json.robot
@@ -1,61 +1,61 @@
 *** Settings ***
-Library         REST                            localhost:8273/
-...             spec=${CURDIR}/swagger/spec_20.json
+Library           REST    localhost:8273/
+...               spec=${CURDIR}/swagger/spec_20.json
 
 *** Test Cases ***
 GET to existing
-    GET         /users/1                        allow_redirects=${None}
+    GET    /users/1    allow_redirects=${None}
 
 GET to non-existing
-    GET         /users/404                      allow_redirects=true
+    GET    /users/404    allow_redirects=true
 
 GET many
-    GET         /users                          allow_redirects=false
+    GET    /users    allow_redirects=false
 
 GET many with query "_limit"
-    GET         /users?_limit=10                allow_redirects=${False}
+    GET    /users?_limit=10    allow_redirects=${False}
 
 GET many with invalid query
-    GET         /users?_invalid=query           timeout=2.0
+    GET    /users?_invalid=query    timeout=2.0
 
 POST with invalid params
-    POST        /users          { "name": "Alexander James Murphy" }
+    POST    /users    { "name": "Alexander James Murphy" }
 
 POST with valid params
-    POST        /users          { "id": 100, "name": "Alexander James Murphy" }
+    POST    /users    { "id": 100, "name": "Alexander James Murphy" }
 
 POST with missing params
-    POST        /users
+    POST    /users
 
 PUT to non-existing
-    PUT         /users/2043
+    PUT    /users/2043
 
 PUT with invalid params
-    PUT         /users/100       { "id": 1801 }
+    PUT    /users/100    { "id": 1801 }
 
 PUT with valid params
-    PUT         /users/100       { "address": { "city": "Delta City" } }
+    PUT    /users/100    { "address": { "city": "Delta City" } }
 
 PUT with missing params
-    PUT         /users/100
+    PUT    /users/100
 
 PATCH to non-existing
-    PATCH        /users/2043
+    PATCH    /users/2043
 
 PATCH with invalid params
-    PATCH       /users/100       { "nickname": "murph" }
+    PATCH    /users/100    { "nickname": "murph" }
 
 PATCH with valid params
-    PATCH       /users/100       { "username": "murph" }
+    PATCH    /users/100    { "username": "murph" }
 
 PATCH with missing params
-    PATCH        /users/100
+    PATCH    /users/100
 
 DELETE to non-existing
-    DELETE      /users/2043
+    DELETE    /users/2043
 
 DELETE to existing
-    DELETE      /users/100
+    DELETE    /users/100
 
 DELETE to invalid, but with no validations
-    DELETE      /invalid         validate=false
+    DELETE    /invalid    validate=false

--- a/atest/spec_yaml.robot
+++ b/atest/spec_yaml.robot
@@ -1,61 +1,61 @@
 *** Settings ***
-Library         REST                            localhost:8273/
-...             spec=${CURDIR}/swagger/spec_20.yaml
+Library           REST    localhost:8273/
+...               spec=${CURDIR}/swagger/spec_20.yaml
 
 *** Test Cases ***
 GET to existing
-    GET         /users/1                        allow_redirects=${None}
+    GET    /users/1    allow_redirects=${None}
 
 GET to non-existing
-    GET         /users/404                      allow_redirects=true
+    GET    /users/404    allow_redirects=true
 
 GET many
-    GET         /users                          allow_redirects=false
+    GET    /users    allow_redirects=false
 
 GET many with query "_limit"
-    GET         /users?_limit=10                allow_redirects=${False}
+    GET    /users?_limit=10    allow_redirects=${False}
 
 GET many with invalid query
-    GET         /users?_invalid=query           timeout=2.0
+    GET    /users?_invalid=query    timeout=2.0
 
 POST with invalid params
-    POST        /users          { "name": "Alexander James Murphy" }
+    POST    /users    { "name": "Alexander James Murphy" }
 
 POST with valid params
-    POST        /users          { "id": 100, "name": "Alexander James Murphy" }
+    POST    /users    { "id": 100, "name": "Alexander James Murphy" }
 
 POST with missing params
-    POST        /users
+    POST    /users
 
 PUT to non-existing
-    PUT         /users/2043
+    PUT    /users/2043
 
 PUT with invalid params
-    PUT         /users/100       { "id": 1801 }
+    PUT    /users/100    { "id": 1801 }
 
 PUT with valid params
-    PUT         /users/100       { "address": { "city": "Delta City" } }
+    PUT    /users/100    { "address": { "city": "Delta City" } }
 
 PUT with missing params
-    PUT         /users/100
+    PUT    /users/100
 
 PATCH to non-existing
-    PATCH        /users/2043
+    PATCH    /users/2043
 
 PATCH with invalid params
-    PATCH       /users/100       { "nickname": "murph" }
+    PATCH    /users/100    { "nickname": "murph" }
 
 PATCH with valid params
-    PATCH       /users/100       { "username": "murph" }
+    PATCH    /users/100    { "username": "murph" }
 
 PATCH with missing params
-    PATCH        /users/100
+    PATCH    /users/100
 
 DELETE to non-existing
-    DELETE      /users/2043
+    DELETE    /users/2043
 
 DELETE to existing
-    DELETE      /users/100
+    DELETE    /users/100
 
 DELETE to invalid, but with no validations
-    DELETE      /invalid         validate=false
+    DELETE    /invalid    validate=false

--- a/atest/validations.robot
+++ b/atest/validations.robot
@@ -1,45 +1,42 @@
 *** Settings ***
-Library         REST        schema={ "examples": null }
-Suite setup     Set expectations
-Test setup      DELETE      http://localhost:8273/state
-
+Library           REST    schema={ "examples": null }
+Suite Setup       Set expectations
+Test Setup        DELETE    http://localhost:8273/state
 
 *** Variables ***
-${api_url}=     http://localhost:8273
-
+${api_url}=       http://localhost:8273
 
 *** Keywords ***
 Set expectations
-    Expect response         { "status": { "enum": [200, 201, 204, 400] } }
-    Expect response         { "seconds": { "maximum": 1.5 } }
-
+    Expect response    { "status": { "enum": [200, 201, 204, 400] } }
+    Expect response    { "seconds": { "maximum": 1.5 } }
 
 *** Test Cases ***
 GET existing user
-    GET         ${api_url}/users/1
-    String      response body username      minLength=4
-    String      response body email         format=email
-    String      response body address geo lat   "-37.3159"
+    GET    ${api_url}/users/1
+    String    response body username    minLength=4
+    String    response body email    format=email
+    String    response body address geo lat    "-37.3159"
 
 GET many users
-    GET         ${api_url}/users?_limit=5
-    Array       response body           maxItems=5
+    GET    ${api_url}/users?_limit=5
+    Array    response body    maxItems=5
 
 POST with valid params
-    POST        ${api_url}/users        { "id": 15, "name": "Gil Alexander" }
-    Object      response body           required=["id", "name"]
+    POST    ${api_url}/users    { "id": 15, "name": "Gil Alexander" }
+    Object    response body    required=["id", "name"]
 
 PUT with invalid params
-    PUT         ${api_url}/users/5      { "id": 1969 }
-    String      response body error     pattern=read-only
+    PUT    ${api_url}/users/5    { "id": 1969 }
+    String    response body error    pattern=read-only
 
 PUT with valid params
-    PUT         ${api_url}/users/5      { "website": "https://robocon.io" }
-    String      response body website   format=uri
+    PUT    ${api_url}/users/5    { "website": "https://robocon.io" }
+    String    response body website    format=uri
 
 PATCH with invalid params
-    PATCH       ${api_url}/users/8      { "id": "1984" }
-    String      response body error     pattern="not allowed$"
+    PATCH    ${api_url}/users/8    { "id": "1984" }
+    String    response body error    pattern="not allowed$"
 
 DELETE existing
-    DELETE      ${api_url}/users/6
+    DELETE    ${api_url}/users/6

--- a/src/REST/__init__.py
+++ b/src/REST/__init__.py
@@ -131,6 +131,7 @@ class REST(Keywords):
             "path": "",
             "query": {},
             "body": None,
+            "data": None,
             "headers": {
                 "Accept": REST._input_string(accept),
                 "Content-Type": REST._input_string(content_type),
@@ -382,3 +383,17 @@ class REST(Keywords):
             else:
                 return value
         return [value, value]
+
+    @staticmethod
+    def _input_data(value):
+        try:
+            data = REST._input_object(value)
+        except RuntimeError:
+            if isinstance(value, bytes):
+                data = value
+            elif path.isfile(value):
+                with open(value, "rb") as file:
+                    data = file.read()
+            else:
+                raise RuntimeError("Data is not a dictionary, bytes, or path to a file")
+        return data

--- a/src/REST/keywords.py
+++ b/src/REST/keywords.py
@@ -339,6 +339,7 @@ class Keywords(object):
         allow_redirects=None,
         validate=True,
         headers=None,
+        data=None,
     ):
         """*Sends a GET request to the endpoint.*
 
@@ -359,6 +360,8 @@ class Keywords(object):
         by expectation keywords and a spec given on library init.
 
         ``headers``: Headers as a JSON object to add or override for the request.
+
+        ``data``: Data as a dictionary, bytes or a file-like object
 
         *Examples*
 
@@ -386,6 +389,8 @@ class Keywords(object):
         validate = self._input_boolean(validate)
         if headers:
             request["headers"].update(self._input_object(headers))
+        if data:
+            request["data"] = self._input_data(data)
         return self._request(endpoint, request, validate)["response"]
 
     @keyword(name="POST", tags=("http",))
@@ -397,6 +402,7 @@ class Keywords(object):
         allow_redirects=None,
         validate=True,
         headers=None,
+        data=None,
     ):
         """*Sends a POST request to the endpoint.*
 
@@ -417,6 +423,8 @@ class Keywords(object):
 
         ``headers``: Headers as a JSON object to add or override for the request.
 
+        ``data``: Data as a dictionary, bytes or a file-like object
+
         *Examples*
 
         | `POST` | /users | { "id": 11, "name": "Gil Alexander" } |
@@ -433,6 +441,8 @@ class Keywords(object):
         validate = self._input_boolean(validate)
         if headers:
             request["headers"].update(self._input_object(headers))
+        if data:
+            request["data"] = self._input_data(data)
         return self._request(endpoint, request, validate)["response"]
 
     @keyword(name="PUT", tags=("http",))
@@ -444,6 +454,7 @@ class Keywords(object):
         allow_redirects=None,
         validate=True,
         headers=None,
+        data=None,
     ):
         """*Sends a PUT request to the endpoint.*
 
@@ -464,6 +475,8 @@ class Keywords(object):
 
         ``headers``: Headers as a JSON object to add or override for the request.
 
+        `data``: Data as a dictionary, bytes or a file-like object
+
         *Examples*
 
         | `PUT` | /users/2 | { "name": "Julie Langford", "username": "jlangfor" } |
@@ -480,6 +493,8 @@ class Keywords(object):
         validate = self._input_boolean(validate)
         if headers:
             request["headers"].update(self._input_object(headers))
+        if data:
+            request["data"] = self._input_data(data)
         return self._request(endpoint, request, validate)["response"]
 
     @keyword(name="PATCH", tags=("http",))
@@ -491,6 +506,7 @@ class Keywords(object):
         allow_redirects=None,
         validate=True,
         headers=None,
+        data=None,
     ):
         """*Sends a PATCH request to the endpoint.*
 
@@ -511,6 +527,8 @@ class Keywords(object):
 
         ``headers``: Headers as a JSON object to add or override for the request.
 
+        `data``: Data as a dictionary, bytes or a file-like object
+
         *Examples*
 
         | `PATCH` | /users/4 | { "name": "Clementine Bauch" } |
@@ -527,6 +545,8 @@ class Keywords(object):
         validate = self._input_boolean(validate)
         if headers:
             request["headers"].update(self._input_object(headers))
+        if data:
+            request["data"] = self._input_data(data)
         return self._request(endpoint, request, validate)["response"]
 
     @keyword(name="DELETE", tags=("http",))
@@ -1272,6 +1292,22 @@ class Keywords(object):
             )
         return self.instances
 
+    @keyword(name="Set SSL Verify", tags=("settings",))
+    def set_ssl_verify(self, ssl_verify=True):
+        """*Sets new SSL verify option*
+
+        ``ssl_verify``: True/False or a location to a certificate file
+
+        *Examples*
+
+        | `Set SSL Verify` |  |
+        | `Set SSL Verify` | False |
+        | `Set SSL Verify` | cert.pem |
+        """
+        self.request["sslVerify"] = self._input_ssl_verify(ssl_verify)
+        return self.request["sslVerify"]
+
+
     ### Internal methods
 
     def _request(self, endpoint, request, validate=True):
@@ -1291,6 +1327,7 @@ class Keywords(object):
                 request["url"],
                 params=request["query"],
                 json=request["body"],
+                data=request["data"],
                 headers=request["headers"],
                 proxies=request["proxies"],
                 cert=request["cert"],


### PR DESCRIPTION
- Adds support for the curl flag --data-binary by adding a data parameter to GET, POST, PUT, and PATCH requests. The data can be bytes or a path to a file containing bytes-typed data.

- Adds a Set SSL Verify keyword to allow changing the SSL verification after a library has been imported, so we don't need to import the library multiple times. The reason for this is that our requests need verification, but in order to get our certificate file we need to make one call without verification (chicken-egg problem).

- Fixes `nox -s atest` by converting whitespace looking character to actual whitespace
