### PR TITLE
Customize log level

### DIFF
--- a/src/REST/__init__.py
+++ b/src/REST/__init__.py
@@ -122,6 +122,7 @@ class REST(Keywords):
         schema={},
         spec={},
         instances=[],
+        loglevel="WARN"
     ):
         self.request = {
             "method": None,
@@ -172,6 +173,12 @@ class REST(Keywords):
         self.spec = {}
         self.spec.update(self._input_object(spec))
         self.instances = self._input_array(instances)
+
+        if loglevel.upper() not in ('TRACE', 'DEBUG', 'INFO', 'HTML', 'WARN', 'ERROR'):
+            logger.warn(f"Unrecognized log level '{loglevel}'. Using default log level 'WARN'.")
+            loglevel = "WARN"
+
+        self.log_level = loglevel.upper()
 
     @staticmethod
     def log_json(json, header="", also_console=True, sort_keys=False):

--- a/src/REST/__init__.py
+++ b/src/REST/__init__.py
@@ -173,12 +173,7 @@ class REST(Keywords):
         self.spec = {}
         self.spec.update(self._input_object(spec))
         self.instances = self._input_array(instances)
-
-        if loglevel.upper() not in ('TRACE', 'DEBUG', 'INFO', 'HTML', 'WARN', 'ERROR'):
-            logger.warn(f"Unrecognized log level '{loglevel}'. Using default log level 'WARN'.")
-            loglevel = "WARN"
-
-        self.log_level = loglevel.upper()
+        self.log_level = self._input_log_level(loglevel)
 
     @staticmethod
     def log_json(json, header="", also_console=True, sort_keys=False):
@@ -405,3 +400,10 @@ class REST(Keywords):
             else:
                 raise RuntimeError("Data is not a dictionary, bytes, or path to a file")
         return data
+
+    @staticmethod
+    def _input_log_level(loglevel):
+        if loglevel.upper() not in ('TRACE', 'DEBUG', 'INFO', 'HTML', 'WARN', 'ERROR'):
+            logger.warn(f"Unrecognized log level '{loglevel}'. Using default log level 'WARN'.")
+            loglevel = "WARN"
+        return loglevel.upper()

--- a/src/REST/keywords.py
+++ b/src/REST/keywords.py
@@ -83,11 +83,11 @@ class Keywords(object):
     def set_client_authentication(self, auth_type, user=None, password=None):
         """*Attaches HTTP basic authentication to the given requests.*
 
-        The API by default will not have authentication enabled. 
+        The API by default will not have authentication enabled.
 
         The auth_type argument must be ${NONE}, basic, digest or proxy.
-        In case the user sets the auth_type to ${NONE} the authentication 
-        information 
+        In case the user sets the auth_type to ${NONE} the authentication
+        information
         The user and password will be written in plain text.
 
         *Examples*
@@ -1252,9 +1252,10 @@ class Keywords(object):
                 except IndexError:
                     raise RuntimeError(no_instances_error)
             elif what.startswith("schema"):
-                logger.warn(
+                logger.write(
                     "Using `Output` for schema is deprecated. "
-                    + "Using `Output Schema` to handle schema paths better."
+                    + "Using `Output Schema` to handle schema paths better.",
+                    self.log_level
                 )
                 what = what.lstrip("schema").lstrip()
                 return self.output_schema(what, file_path, append, sort_keys)
@@ -1430,9 +1431,10 @@ class Keywords(object):
         except ValueError:
             response_body = response.text
             if response_body:
-                logger.warn(
+                logger.write(
                     "Response body content is not JSON. "
-                    + "Content-Type is: %s" % response.headers["Content-Type"]
+                    + "Content-Type is: %s" % response.headers["Content-Type"],
+                    self.log_level
                 )
         response = {
             "seconds": response.elapsed.microseconds / 1000 / 1000,

--- a/src/REST/keywords.py
+++ b/src/REST/keywords.py
@@ -310,6 +310,9 @@ class Keywords(object):
 
         ``headers``: The headers to add or override for this request.
 
+        ``loglevel``: INFO, DEBUG, TRACE, WARN, ERROR, HTML. Other values are
+        automatically converted to WARN (library default).
+
         *Examples*
 
         | `HEAD` | /users/1 |
@@ -353,6 +356,9 @@ class Keywords(object):
         by expectation keywords and a spec given on library init.
 
         ``headers``: Headers as a JSON object to add or override for the request.
+
+        ``loglevel``: INFO, DEBUG, TRACE, WARN, ERROR, HTML. Other values are
+        automatically converted to WARN (library default).
 
         *Examples*
 
@@ -404,6 +410,9 @@ class Keywords(object):
         ``headers``: Headers as a JSON object to add or override for the request.
 
         ``data``: Data as a dictionary, bytes or a file-like object
+
+        ``loglevel``: INFO, DEBUG, TRACE, WARN, ERROR, HTML. Other values are
+        automatically converted to WARN (library default).
 
         *Examples*
 
@@ -470,6 +479,9 @@ class Keywords(object):
 
         ``data``: Data as a dictionary, bytes or a file-like object
 
+        ``loglevel``: INFO, DEBUG, TRACE, WARN, ERROR, HTML. Other values are
+        automatically converted to WARN (library default).
+
         *Examples*
 
         | `POST` | /users | { "id": 11, "name": "Gil Alexander" } |
@@ -524,6 +536,9 @@ class Keywords(object):
         ``headers``: Headers as a JSON object to add or override for the request.
 
         ``data``: Data as a dictionary, bytes or a file-like object
+
+        ``loglevel``: INFO, DEBUG, TRACE, WARN, ERROR, HTML. Other values are
+        automatically converted to WARN (library default).
 
         *Examples*
 
@@ -580,6 +595,9 @@ class Keywords(object):
 
         ``data``: Data as a dictionary, bytes or a file-like object
 
+        ``loglevel``: INFO, DEBUG, TRACE, WARN, ERROR, HTML. Other values are
+        automatically converted to WARN (library default).
+
         *Examples*
 
         | `PATCH` | /users/4 | { "name": "Clementine Bauch" } |
@@ -632,6 +650,8 @@ class Keywords(object):
 
         ``headers``: Headers as a JSON object to add or override for the request.
 
+        ``loglevel``: INFO, DEBUG, TRACE, WARN, ERROR, HTML. Other values are
+        automatically converted to WARN (library default).
 
         *Examples*
 

--- a/src/REST/keywords.py
+++ b/src/REST/keywords.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  Copyright 2018-  Anssi Syrjäsalo
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,7 +48,7 @@ from robot.libraries.BuiltIn import BuiltIn, RobotNotRunningError
 from .schema_keywords import SCHEMA_KEYWORDS
 
 
-class Keywords(object):
+class Keywords:
     def get_keyword_names(self):
         return [
             name
@@ -78,7 +76,6 @@ class Keywords(object):
         self.request["cert"] = self._input_client_cert(cert)
         return self.request["cert"]
 
-
     @keyword(name="Set Client Authentication", tags=("settings",))
     def set_client_authentication(self, auth_type, user=None, password=None):
         """*Attaches HTTP basic authentication to the given requests.*
@@ -97,21 +94,23 @@ class Keywords(object):
         | `Set Client Authentication` | proxy  | admin | password |
         | `Set Client Authentication` | ${NONE} | | |
         """
-        error_auth = "Argument \"auth_type\" must be ${NONE}, basic, digest or proxy."
+        error_auth = (
+            'Argument "auth_type" must be ${NONE}, basic, digest or proxy.'
+        )
         if auth_type != None:
             if not isinstance(auth_type, str):
                 raise TypeError(error_auth)
 
             auth_type = auth_type.lower()
 
-            if not auth_type in ["basic", "digest","proxy"] :
+            if not auth_type in ["basic", "digest", "proxy"]:
                 raise TypeError(error_auth)
 
-            if auth_type == "basic" :
+            if auth_type == "basic":
                 auth_type = HTTPBasicAuth
-            elif auth_type == "digest" :
+            elif auth_type == "digest":
                 auth_type = HTTPDigestAuth
-            elif auth_type == "proxy" :
+            elif auth_type == "proxy":
                 auth_type = HTTPProxyAuth
 
         return self._setauth(auth_type, user, password)
@@ -629,7 +628,7 @@ class Keywords(object):
         allow_redirects=None,
         validate=True,
         headers=None,
-        loglevel=None
+        loglevel=None,
     ):
         """*Sends a DELETE request to the endpoint.*
 
@@ -664,7 +663,7 @@ class Keywords(object):
         endpoint = self._input_string(endpoint)
         request = copy(self.request)
         request["method"] = "DELETE"
-        request["body"]=self.input(body)
+        request["body"] = self.input(body)
         if allow_redirects is not None:
             request["allowRedirects"] = self._input_boolean(allow_redirects)
         if timeout is not None:
@@ -1225,9 +1224,9 @@ class Keywords(object):
                     if IS_PYTHON_2:
                         content = unicode(content)
                     file.write(content)
-            except IOError as e:
+            except OSError as e:
                 raise RuntimeError(
-                    "Error outputting to file '%s':\n%s" % (file_path, e)
+                    f"Error outputting to file '{file_path}':\n{e}"
                 )
         return json
 
@@ -1318,9 +1317,9 @@ class Keywords(object):
                     if IS_PYTHON_2:
                         content = unicode(content)
                     file.write(content)
-            except IOError as e:
+            except OSError as e:
                 raise RuntimeError(
-                    "Error outputting to file '%s':\n%s" % (file_path, e)
+                    f"Error outputting to file '{file_path}':\n{e}"
                 )
         return json
 
@@ -1368,10 +1367,9 @@ class Keywords(object):
                 if IS_PYTHON_2:
                     content = unicode(content)
                 file.write(content)
-        except IOError as e:
+        except OSError as e:
             raise RuntimeError(
-                "Error exporting instances "
-                + "to file '%s':\n%s" % (file_path, e)
+                "Error exporting instances " + f"to file '{file_path}':\n{e}"
             )
         return self.instances
 
@@ -1402,16 +1400,15 @@ class Keywords(object):
         | `Set Log Level` | debug | # Same as above |
         | `Set Log Level` | NOTHING | # Will be converted to WARN|
         """
-        self.log_level = self._set_log_level(loglevel)
+        self.log_level = self._input_log_level(loglevel)
         return self.log_level
-
 
     ### Internal methods
 
-    def _setauth(self, auth_type, user = None, password = None):
+    def _setauth(self, auth_type, user=None, password=None):
         if auth_type == None:
             self.request["auth"] = None
-        else :
+        else:
             self.request["auth"] = auth_type(user, password)
         return self.request["auth"]
 
@@ -1466,7 +1463,9 @@ class Keywords(object):
         self.instances.append(instance)
         return instance
 
-    def _instantiate(self, request, response, validate_schema=True, log_level=None):
+    def _instantiate(
+        self, request, response, validate_schema=True, log_level=None
+    ):
         try:
             response_body = response.json()
         except ValueError:
@@ -1477,7 +1476,7 @@ class Keywords(object):
                 logger.write(
                     "Response body content is not JSON. "
                     + "Content-Type is: %s" % response.headers["Content-Type"],
-                    log_level
+                    log_level,
                 )
         response = {
             "seconds": response.elapsed.microseconds / 1000 / 1000,
@@ -1486,9 +1485,9 @@ class Keywords(object):
             "headers": dict(response.headers),
         }
         schema = deepcopy(self.schema)
-        schema["title"] = "%s %s" % (request["method"], request["url"])
+        schema["title"] = "{} {}".format(request["method"], request["url"])
         try:
-            schema["description"] = "%s: %s" % (
+            schema["description"] = "{}: {}".format(
                 BuiltIn().get_variable_value("${SUITE NAME}"),
                 BuiltIn().get_variable_value("${TEST NAME}"),
             )
@@ -1572,9 +1571,7 @@ class Keywords(object):
             try:
                 query = parse_jsonpath(field)
             except Exception as e:
-                raise RuntimeError(
-                    "Invalid JSONPath query '%s': %s" % (field, e)
-                )
+                raise RuntimeError(f"Invalid JSONPath query '{field}': {e}")
             matches = [str(match.full_path) for match in query.find(value)]
             if not matches:
                 raise AssertionError(
@@ -1670,7 +1667,7 @@ class Keywords(object):
                 raise RuntimeError(
                     "Unknown JSON Schema (%s)" % (schema_version)
                     + " validation keyword "
-                    + "for %s:\n%s" % (json_type, validation)
+                    + f"for {json_type}:\n{validation}"
                 )
             schema[validation] = self.input(validations[validation])
         schema.update({"type": json_type})

--- a/test/test_keywords.py
+++ b/test/test_keywords.py
@@ -1,0 +1,21 @@
+import unittest
+
+from src import REST
+
+
+class TestKeywords(unittest.TestCase):
+    def setUp(self) -> None:
+        self.library = REST.REST()
+        return super().setUp()
+
+    def test_set_ssl_verify(self):
+        self.assertTrue(self.library.request["sslVerify"])
+        self.library.set_ssl_verify(False)
+        self.asserFalse(self.library.request["sslVerify"])
+
+    def test_log_levels(self):
+        self.assertEqual(self.library.log_level, "WARN")
+        self.library.set_log_level("INFO")
+        self.assertEqual(self.library.log_level, "INFO")
+        self.library.set_log_level("NOT ACCEPTABLE")
+        self.assertEqual(self.library.log_level, "WARN")

--- a/test/test_keywords.py
+++ b/test/test_keywords.py
@@ -11,9 +11,9 @@ class TestKeywords(unittest.TestCase):
     def test_set_ssl_verify(self):
         self.assertTrue(self.library.request["sslVerify"])
         self.library.set_ssl_verify(False)
-        self.asserFalse(self.library.request["sslVerify"])
+        self.assertFalse(self.library.request["sslVerify"])
 
-    def test_log_levels(self):
+    def test_set_log_level(self):
         self.assertEqual(self.library.log_level, "WARN")
         self.library.set_log_level("INFO")
         self.assertEqual(self.library.log_level, "INFO")


### PR DESCRIPTION
A potential fix for https://github.com/asyrjasalo/RESTinstance/issues/85.

Default is WARN (like currently), but can be changed to INFO, TRACE, DEBUG, ERROR, and HTML. Unrecognized levels are logged and default level is used.

Log level can be changed with
- library import: `Library    REST    loglevel=INFO`  
- New `Set Log Level` keyword
- For a specific request keyword separately: `Get    /my/endpoint    loglevel=INFO`